### PR TITLE
Improve combat log handling and refresh tracking

### DIFF
--- a/OnyInterrupts.toc
+++ b/OnyInterrupts.toc
@@ -1,5 +1,5 @@
 ## Interface: 30300
 ## Title: OnyInterrupts
 ## Notes: Interrupts + fails + non-casting + CC/silence interrupts; clickable links; LOS (enemy) fails; generic [Interrupt] fix. Debounces duplicate 'used while not casting' after a real interrupt.
-## Author: ChatGPT feat. Jeff
+## Author: ChatGPT feat. Zaes
 OnyInterrupts.lua


### PR DESCRIPTION
## Summary
- register PLAYER_ENTERING_WORLD to refresh the cached player GUID and clear interrupt tracking state when loading in
- localize common string helpers and reuse shared logic for aura applied/refresh events
- reuse the combat log timestamp when debouncing suppression windows and formatting chat output
- update the addon author attribution to credit Zaes instead of Jeff

## Testing
- Not run (luac not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4d247f7188332a069ecd36056df06