### PR TITLE
Add chat verbosity modes to reduce dungeon spam

### DIFF
--- a/OnyInterrupts.toc
+++ b/OnyInterrupts.toc
@@ -2,4 +2,5 @@
 ## Title: OnyInterrupts
 ## Notes: Interrupts + fails + non-casting + CC/silence interrupts; clickable links; LOS (enemy) fails; generic [Interrupt] fix. Debounces duplicate 'used while not casting' after a real interrupt.
 ## Author: ChatGPT feat. Zaes
+## SavedVariables: OnyInterruptsDB
 OnyInterrupts.lua


### PR DESCRIPTION
## Summary
- add saved-variable backed verbosity modes with slash commands so players can select all, self, or minimal chat output
- route combat log announcements through a notifier that honors the selected mode and persists between sessions

## Testing
- ⚠️ `luac -p OnyInterrupts.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6276ca89c8332a48623a88ec1e34b